### PR TITLE
Delete deprecated `reviewers` option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
     interval: daily
     time: "20:00"
   open-pull-requests-limit: 10
-  reviewers:
-  - rastamhadi
   assignees:
   - rastamhadi
   versioning-strategy: increase


### PR DESCRIPTION
https://github.com/rastamhadi/tomodachi/pull/853#issuecomment-2895822495

> The `reviewers` field in the `dependabot.yml` file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

